### PR TITLE
also load module res_rtp_multicast to avoid undefined symbol error

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -139,6 +139,7 @@ load=res_pjsip_registrar
 load=res_pjsip_sdp_rtp
 load=res_pjsip_session
 load=res_rtp_asterisk
+load=res_rtp_multicast
 load=res_sorcery_astdb
 load=res_sorcery_config
 load=res_sorcery_memory


### PR DESCRIPTION
Fixes this problem:
```
debian9.localdomain asterisk[6707]: [May  4 22:59:09] WARNING[6707]: loader.c:583 load_dlopen: Error loading module 'chan_rtp': /usr/lib/asterisk/modules/chan_rtp.so: undefined symbol: ast_multicast_rtp_options_get_format
debian9.localdomain asterisk[6707]: [May  4 22:59:09] WARNING[6707]: loader.c:1186 load_resource: Module 'chan_rtp' could not be loaded.
```