### PR TITLE
Replace outdated btx.hanse.de with running neu-ulm server

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -154,7 +154,7 @@ same = n,Playback(hello-world)
 same = n,Hangup()
 
 exten = 01910,1,Answer()
-same = n,Softmodem(btx.hanse.de,20000,v(V23)ld(8)s(1))
+same = n,Softmodem(195.201.94.166,20000,v(V23)ld(8)s(1))
 same = n,Hangup()
 EOF
 


### PR DESCRIPTION
btx.hanse.de has been offline for a long time. Use IP address of the only known running instance publicly available.